### PR TITLE
Winzige Korrektur in Ana1

### DIFF
--- a/Ana1.tex
+++ b/Ana1.tex
@@ -253,7 +253,7 @@ $J:=\{A \subseteq \MdR: A$ ist eine IM $\};$ $\MdN := \displaystyle\bigcap_{ A\i
 
 \begin{beweis}
 \begin{liste}
-\item $1 \in A \ \forall A \in J \folgt x + 1 \in A \ \forall x in A\ \forall A \in J \folgt x+1 \in \MdN\ \forall x in \MdN$
+\item $1 \in A \ \forall A \in J \folgt x + 1 \in A \ \forall x \in A\ \forall A \in J \folgt x+1 \in \MdN\ \forall x \in \MdN$
 \item folgt aus der Definition von $\MdN$
 \item Annahme: $\MdN$ ist nach oben beschränkt. \textbf{(A15)}: $s := \sup{\MdN}$. 1.3 $\folgt \ \exists n \in\MdN: n > s - 1$; \textbf{(1)} $\folgt n+1 \in \MdN \folgt n+1 > s$; Widerspruch
 \item folgt aus (3)


### PR DESCRIPTION
Es fehlten zwei `\`.
