### PR TITLE
Analysis I: Struktur an WS2016/2017 angepasst

### DIFF
--- a/Ana1.tex
+++ b/Ana1.tex
@@ -315,6 +315,7 @@ Sei $\emptyset \ne M \subseteq \MdR$.
 \item Ist $M \subseteq \MdN$, so existiert $\min{M}$
 \item Ist $M \subseteq \MdZ$ nach oben beschränkt, so existiert $\max{M}$; ist $M \subseteq \MdZ$ nach unten beschränkt, so existiert $\min{M}$.
 \item Ist $a \in \MdR$, so existiert genau ein $k \in \MdZ: k \le a \ < k+1$. Bezeichnung: $[a] := k$.
+\item Sind $x,y \in \MdR$ und $x<y$, so existiert ein $r \in \MdQ: x < r < y$.
 \end{liste}
 \end{satz}
 
@@ -322,16 +323,9 @@ Sei $\emptyset \ne M \subseteq \MdR$.
 \item $ 1 \le n \ \forall n \in M \folgt M $ ist nach unten beschränkt. 1.2 $\folgt \ \exists \alpha = \inf{M}$ mit $\alpha + 1 $ ist keine untere Schranke von $M$. $\folgt \ \exists m \in M: m < \alpha + 1$. Sei $n \in M$. Annahme: $n < m \folgt n <  m < \alpha +1 \le n +1 \folgt n < m < n+1$. Da $n \in \MdN$: Widerspruch.
 \item \textit{Zur Übung}
 \item $M := \{ z \in \MdZ: z \le a \}$. Annahme: $M = \emptyset\folgt z > a \ \forall z \in \MdZ \folgt -n > a \ \forall n \in \MdN \folgt n < -a \ \forall n \in \MdN$. Widerspruch zu 2.1(3); also: $M \ne \emptyset$. (2) $\folgt \ \exists k := \max{M}$.
+\item $ y-x > 0 \stackrel{2.1(4)}{\folgt} \ \exists n \in \MdN: n > \frac{1}{y-x} \folgt \frac{1}{n} < y-x \folgt x + \frac{1}{n} < y $\\
+$ m := [nx] \in \MdZ \folgt m < nx < m+1 \folgt \frac{m}{n} \le x < \frac{m+1}{n} = \frac{m}{n} + \frac{1}{n} \le x + \frac{1}{n} \folgt x < \stackrel{:= r }{\frac{m+1}{n}} < y$
 \end{beweise}
-
-\begin{satz}[Zwischen zwei reellen Zahlen liegt stets eine rationale]
-Sind $x,y \in \MdR$ und $x<y$, so existiert ein $r \in \MdQ: x < r < y$.
-\end{satz}
-
-\begin{beweis}
-$$ y-x > 0 \mbox{ 2.1(4) } \folgt \ \exists n \in \MdN: n > \frac{1}{y-x} \folgt \frac{1}{n} < y-x \folgt x + \frac{1}{n} < y $$
-$$ m := [nx] \in \MdZ \folgt m < nx < m+1 \folgt \frac{m}{n} \le x < \frac{m+1}{n} = \frac{m}{n} + \frac{1}{n} \le x + \frac{1}{n} \folgt x < \stackrel{:= r }{\frac{m+1}{n}} < y$$
-\end{beweis}
 
 \chapter{Folgen, Abzählbarkeit}
 


### PR DESCRIPTION
Der Mitschrieb basiert grundsätzlich auf dem WS04/05. Ich weiß nicht, ob es bei Mitschriebwiki typisch ist, die Mitschriebe an die aktuellen Vorlesungen anzupassen. Falls das der Fall ist, gleicht dieser PR einen kleinen strukturellen Unterschied zwischen dem Mitschrieb und der tatsächlichen Vorlesung aus.